### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 
 > :warning: This repository is still under development
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/1QQGjzDQqsP1MDC8moUwzJjD/nandomoreirame/autoamazing'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/1QQGjzDQqsP1MDC8moUwzJjD/nandomoreirame/autoamazing.svg' />
-</a>
+
 
 ## Installation
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8